### PR TITLE
Changing the user info box

### DIFF
--- a/client/styles/layouts/_answerpage.scss
+++ b/client/styles/layouts/_answerpage.scss
@@ -96,7 +96,7 @@
   height: 210px;
   margin-bottom: 15px;
   min-width: 170px;
-  padding-top: 10px;
+  padding-top: 21px;
   width: 15%;
 
   .profile-link {
@@ -121,8 +121,8 @@
   }
 
   img {
-    max-height: 150px;
-    max-width: 150px;
+    max-height: 128px;
+    max-width: 128px;
   }
 }
 


### PR DESCRIPTION
The karma number underneath people's icon and name was not aligned
vertically with its containing box, so I changed the image size and
border. The new image size is the size of the default avatar so, if the
image size should be larger, a new default image will be needed.