### PR TITLE
Fixed bugs with markdown and images

### DIFF
--- a/client/scripts/questions/templates/questionDetails.html
+++ b/client/scripts/questions/templates/questionDetails.html
@@ -6,7 +6,7 @@
   <div class="question-section">
     <div class="question-container">
       <div class="question-content">
-        <div class="title" ng-bind-html="title | wizMarkdownFltr"></div>
+        <div class="title" ng-bind-html="title"></div>
         <wiz-markdown content="body"></wiz-markdown>
         <button ng-hide="isSubscribed()" class="subscribe-button action-button" ng-click="subscribeToQuestion()">Subscribe to Question</button>
         <span class="subscribed-label" ng-show="isSubscribed()">Subscribed!</span>

--- a/client/styles/layouts/_answerpage.scss
+++ b/client/styles/layouts/_answerpage.scss
@@ -8,6 +8,10 @@
     color: $blue-darker;
     text-decoration: none;
   }
+
+  img {
+    max-width:  100%;
+  }
 }
 
 .question-section .question-container {


### PR DESCRIPTION
Images in markdown could be any size and would overflow the page. Titles
of posts could contain markdown and therefore have images in them.